### PR TITLE
Typos README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ https://assets.smold.app/api/token/[chainID]/[tokenAddress]/[fileName].[ext]
 ## Usage
 
 It's recommended to use PNG files. They are smaller and faster to load, come in two sizes (32x32 and 128x128) and are supported by all browsers.
-SVG files are also available, but they are larger and slower to load and can hurt performances for poorly optimized assets or very complex ones (ex: curvefi icon).
+SVG files are also available, but they are larger and slower to load and can hurt performance for poorly optimized assets or very complex ones (ex: curvefi icon).
 
 ## (Self) Hosting
 
 The repo comes with two different server systems in `_config`:
 
--   a `golang` server, that serve the assets from github
+-   a `golang` server, that serves the assets from github
 -   a `node` server, configured to work with Vercel. If you want to self host, here is the config we are using:
 
 ```
@@ -81,6 +81,6 @@ $ rsvg-convert -h 32 logo.svg > logo-32.png && rsvg-convert -h 128 logo.svg > lo
 Once ready, create a new directory with the chain ID, or use the existing one,
 and create a new directory for the token address (in lower case for EVM chains, or case sensitive for Solana) you are adding.
 
-Fill-in the details when creating the pull-request, and we'll merge it shortly!
+Fill in the details when creating the pull-request, and we'll merge it shortly!
 
 That's it, thank you!


### PR DESCRIPTION
# Pull Request: Fix Typographical Errors in Documentation

## Description
This pull request addresses minor typographical errors in the documentation to improve clarity and readability.

## Changes Made
1. **Corrected word usage:**
   - `"performances"` → `"performance"`  
     Updated:  
     - From: `"can hurt performances"`  
     - To: `"can hurt performance"`  

2. **Fixed verb form:**
   - `"serve"` → `"serves"`  
     Updated:  
     - From: `"that serve the assets"`  
     - To: `"that serves the assets"`  

3. **Standardized phrasing:**
   - `"Fill-in"` → `"Fill in"`  
     Updated:  
     - From: `"Fill-in the details"`  
     - To: `"Fill in the details"`  

Please review and merge this pull request if no further changes are required. Thank you!

